### PR TITLE
feat: allow fd limit override for systemd service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@
 .plan_cache.json
 .rerun.json
 bolt-debug.log
+/.vscode/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,0 @@
-{
-  "recommendations": [
-    "puppet.puppet-vscode",
-    "Shopify.ruby-lsp"
-  ]
-}

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -24,6 +24,10 @@
 
 * [`ProSA::TelemetryLevel`](#ProSA--TelemetryLevel): A string that conforms to the ProSA `TelemetryLevel` syntax.
 
+### Tasks
+
+* [`version`](#version): Gets the ProSA components versions
+
 ## Classes
 
 ### <a name="prosa"></a>`prosa`
@@ -86,6 +90,7 @@ The following parameters are available in the `prosa` class:
 * [`service_enable`](#-prosa--service_enable)
 * [`service_manage`](#-prosa--service_manage)
 * [`service_ensure`](#-prosa--service_ensure)
+* [`service_limit_nofile`](#-prosa--service_limit_nofile)
 * [`manage_user`](#-prosa--manage_user)
 * [`manage_group`](#-prosa--manage_group)
 * [`user`](#-prosa--user)
@@ -171,6 +176,16 @@ to `false`, which is useful when you want to let the service be managed by anoth
 application.<br />
 
 Default value: `'running'`
+
+##### <a name="-prosa--service_limit_nofile"></a>`service_limit_nofile`
+
+Data type: `Optional[Integer]`
+
+Sets the limit on the number of open file descriptors for the ProSA service.<br />
+This parameter corresponds to the `LimitNOFILE` directive in the systemd service unit file.<br />
+Apply the default system limit when set to `undef`.
+
+Default value: `undef`
 
 ##### <a name="-prosa--manage_user"></a>`manage_user`
 
@@ -383,4 +398,20 @@ ProSA accept non case sensitive levels (like this type).
   * https://docs.rs/prosa-utils/latest/prosa_utils/config/tracing/enum.TelemetryLevel.html
 
 Alias of `Pattern[/\A(?i:error|warn|info|debug|trace|off)\Z/]`
+
+## Tasks
+
+### <a name="version"></a>`version`
+
+Gets the ProSA components versions
+
+**Supports noop?** false
+
+#### Parameters
+
+##### `node_role`
+
+Data type: `String[1]`
+
+The role of the node joining the swarm
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -19,6 +19,7 @@
 ### Defined types
 
 * [`prosa::proc`](#prosa--proc): Allows specialised configurations for ProSA processors
+Use the `prosa::processors` defined type if you want to create processors
 
 ### Data types
 
@@ -237,7 +238,7 @@ Default value: `$prosa::params::telemetry_level`
 Data type: `Optional[Hash[String, String]]`
 
 Configures the ProSA [Telemetry Attributes](https://docs.rs/prosa-utils/latest/prosa_utils/config/observability/struct.Observability.html) directive
-which allows to add custom attributes to telemetry messages.
+which allows to add custom attributes to telemetry messages.<br />
 Refer to the [ProSA book](https://worldline.github.io/ProSA/ch01-02-01-observability.html) for more details on how to configure this directive.
 
 Default value: `undef`
@@ -247,7 +248,7 @@ Default value: `undef`
 Data type: `Hash[String, Hash[String, Hash[String, String]]]`
 
 Configures the ProSA [Observability](https://docs.rs/prosa-utils/latest/prosa_utils/config/observability/struct.Observability.html) directive
-which configure metrics, traces and logs export.
+which configure metrics, traces and logs export.<br />
 Refer to the [ProSA book](https://worldline.github.io/ProSA/ch01-02-01-observability.html) for more details on how to configure this directive.
 
 Default value: `$prosa::params::observability`
@@ -295,17 +296,7 @@ Default value: `{}`
 ### <a name="prosa--proc"></a>`prosa::proc`
 
 Allows specialised configurations for ProSA processors
-
-#### Examples
-
-##### 
-
-```puppet
-class { 'prosa':
-  default_vhost     => false,
-  default_ssl_vhost => false,
-}
-```
+Use the `prosa::processors` defined type if you want to create processors
 
 #### Parameters
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -24,10 +24,6 @@
 
 * [`ProSA::TelemetryLevel`](#ProSA--TelemetryLevel): A string that conforms to the ProSA `TelemetryLevel` syntax.
 
-### Tasks
-
-* [`version`](#version): Gets the ProSA components versions
-
 ## Classes
 
 ### <a name="prosa"></a>`prosa`
@@ -398,20 +394,4 @@ ProSA accept non case sensitive levels (like this type).
   * https://docs.rs/prosa-utils/latest/prosa_utils/config/tracing/enum.TelemetryLevel.html
 
 Alias of `Pattern[/\A(?i:error|warn|info|debug|trace|off)\Z/]`
-
-## Tasks
-
-### <a name="version"></a>`version`
-
-Gets the ProSA components versions
-
-**Supports noop?** false
-
-#### Parameters
-
-##### `node_role`
-
-Data type: `String[1]`
-
-The role of the node joining the swarm
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -70,7 +70,7 @@
 #
 # @param telemetry_attributes
 #   Configures the ProSA [Telemetry Attributes](https://docs.rs/prosa-utils/latest/prosa_utils/config/observability/struct.Observability.html) directive
-#   which allows to add custom attributes to telemetry messages.
+#   which allows to add custom attributes to telemetry messages.<br />
 #   Refer to the [ProSA book](https://worldline.github.io/ProSA/ch01-02-01-observability.html) for more details on how to configure this directive.
 #
 # @example Setting custom telemetry attributes
@@ -83,7 +83,7 @@
 #
 # @param observability
 #   Configures the ProSA [Observability](https://docs.rs/prosa-utils/latest/prosa_utils/config/observability/struct.Observability.html) directive
-#   which configure metrics, traces and logs export.
+#   which configure metrics, traces and logs export.<br />
 #   Refer to the [ProSA book](https://worldline.github.io/ProSA/ch01-02-01-observability.html) for more details on how to configure this directive.
 #
 # @example Setting custom observability configuration
@@ -178,14 +178,15 @@ class prosa (
 
   # Declare ProSA service
   class { 'prosa::service':
-    prosa_name     => $prosa_name,
-    service_name   => $service_name,
-    service_binary => $bin_path,
-    app_conf       => $conf_dir,
-    user           => $user,
-    group          => $group,
-    service_enable => $service_enable,
-    service_ensure => $service_ensure,
-    service_manage => $service_manage,
+    prosa_name           => $prosa_name,
+    service_name         => $service_name,
+    service_binary       => $bin_path,
+    app_conf             => $conf_dir,
+    user                 => $user,
+    group                => $group,
+    service_enable       => $service_enable,
+    service_ensure       => $service_ensure,
+    service_manage       => $service_manage,
+    service_limit_nofile => $service_limit_nofile,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,6 +39,11 @@
 #   to `false`, which is useful when you want to let the service be managed by another 
 #   application.<br />
 #
+# @param service_limit_nofile
+#   Sets the limit on the number of open file descriptors for the ProSA service.<br />
+#   This parameter corresponds to the `LimitNOFILE` directive in the systemd service unit file.<br />
+#   Apply the default system limit when set to `undef`.
+#
 # @param manage_user
 #   When `false`, stops Puppet from creating the user resource.<br />
 #   This is for instances when you have a user, created from another Puppet module, you want 
@@ -112,6 +117,7 @@ class prosa (
   Boolean $service_enable                                         = true,
   Boolean $service_manage                                         = true,
   Variant[Stdlib::Ensure::Service, Boolean] $service_ensure       = 'running',
+  Optional[Integer] $service_limit_nofile                         = undef,
   Boolean $manage_user                                            = true,
   Boolean $manage_group                                           = true,
   String $user                                                    = $prosa::params::user,

--- a/manifests/proc.pp
+++ b/manifests/proc.pp
@@ -1,11 +1,6 @@
 # @summary
 #   Allows specialised configurations for ProSA processors
-#
-# @example
-#   class { 'prosa':
-#     default_vhost     => false,
-#     default_ssl_vhost => false,
-#   }
+#   Use the `prosa::processors` defined type if you want to create processors
 #
 # @param adaptor_config_path
 #   For some ProSA adaptor, they need to have a configuration in addition to processor.

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -11,7 +11,8 @@ class prosa::service (
   String $group                            = $prosa::params::group,
   Boolean $service_enable                  = true,
   Variant[Boolean, String] $service_ensure = 'running',
-  Boolean $service_manage                  = true
+  Boolean $service_manage                  = true,
+  Optional[Integer] $service_limit_nofile  = undef
 ) {
   # The base class must be included first because parameter defaults depend on it
   if ! defined(Class['prosa::params']) {
@@ -36,11 +37,12 @@ class prosa::service (
         group   => $prosa::params::root_group,
         mode    => '0644',
         content => epp('prosa/service.epp', {
-            'prosa_name' => $prosa_name,
-            'user'       => $user,
-            'group'      => $group,
-            'bin_path'   => $service_binary,
-            'conf_path'  => $app_conf,
+            'prosa_name'   => $prosa_name,
+            'user'         => $user,
+            'group'        => $group,
+            'bin_path'     => $service_binary,
+            'conf_path'    => $app_conf,
+            'limit_nofile' => $service_limit_nofile,
         }),
         replace => true,
       }

--- a/spec/acceptance/processors_spec.rb
+++ b/spec/acceptance/processors_spec.rb
@@ -16,14 +16,14 @@ describe 'prosa::processors class' do
 
     pp = <<-MANIFEST
         class { 'prosa':
-          prosa_name      => #{prosa_hash['prosa_name']},
-          service_manage  => false,
-          telemetry_level => 'warn',
+          prosa_name           => #{prosa_hash['prosa_name']},
+          service_manage       => false,
+          telemetry_level      => 'warn',
           telemetry_attributes => {
             'service.name' => 'prosa-service',
             'host.id'      => 'fdbf79e8af94cb7f9e8df36789187052',
           },
-          observability   => {
+          observability        => {
             'metrics' => {
               'prometheus' => {
                 'endpoint' => '0.0.0.0:9090',

--- a/templates/service.epp
+++ b/templates/service.epp
@@ -3,6 +3,7 @@
       String               $group = 'prosa',
       Stdlib::Absolutepath $bin_path = '/usr/local/bin/prosa',
       Stdlib::Absolutepath $conf_path = '/etc/prosa',
+      Optional[Integer]    $limit_nofile = undef,
 | -%>
 [Unit]
 Description=ProSA service for <%= $prosa_name %>
@@ -14,6 +15,9 @@ Type=simple
 User=<%= $user %>
 Group=<%= $group %>
 ExecStart=<%= $bin_path %> -c <%= $conf_path %>
+<% if $limit_nofile { -%>
+LimitNOFILE=<%= $limit_nofile %>
+<% } -%>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Since ProSA is a backend, it need to handle many sockets.
Sometime it reach the system file descriptor limit, and so the limit need to be increase.
To do so, we use the `LimitNOFILE` option from systemd that allow more fd for the service.