### PR TITLE
feat: add telemetry_attributes to add labels for observability

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -38,6 +38,41 @@ A description of what this class does
 class { 'prosa': }
 ```
 
+##### Setting custom telemetry attributes
+
+```puppet
+class { 'prosa':
+  telemetry_attributes => {
+    'service.name' => 'prosa-service',
+    'host.id'      => 'fdbf79e8af94cb7f9e8df36789187052',
+  }
+}
+```
+
+##### Setting custom observability configuration
+
+```puppet
+class { 'prosa':
+  observability => {
+    'metrics' => {
+      'stdout' => {
+        'level' => 'info',
+      },
+    },
+    'traces'  => {
+      'stdout' => {
+        'level' => 'info',
+      },
+    },
+    'logs'    => {
+      'stdout' => {
+        'level' => 'info',
+      },
+    },
+  }
+}
+```
+
 #### Parameters
 
 The following parameters are available in the `prosa` class:
@@ -56,6 +91,7 @@ The following parameters are available in the `prosa` class:
 * [`user`](#-prosa--user)
 * [`group`](#-prosa--group)
 * [`telemetry_level`](#-prosa--telemetry_level)
+* [`telemetry_attributes`](#-prosa--telemetry_attributes)
 * [`observability`](#-prosa--observability)
 
 ##### <a name="-prosa--prosa_name"></a>`prosa_name`
@@ -185,12 +221,23 @@ which adjusts the verbosity of telemetry messages recorded.
 
 Default value: `$prosa::params::telemetry_level`
 
+##### <a name="-prosa--telemetry_attributes"></a>`telemetry_attributes`
+
+Data type: `Optional[Hash[String, String]]`
+
+Configures the ProSA [Telemetry Attributes](https://docs.rs/prosa-utils/latest/prosa_utils/config/observability/struct.Observability.html) directive
+which allows to add custom attributes to telemetry messages.
+Refer to the [ProSA book](https://worldline.github.io/ProSA/ch01-02-01-observability.html) for more details on how to configure this directive.
+
+Default value: `undef`
+
 ##### <a name="-prosa--observability"></a>`observability`
 
 Data type: `Hash[String, Hash[String, Hash[String, String]]]`
 
 Configures the ProSA [Observability](https://docs.rs/prosa-utils/latest/prosa_utils/config/observability/struct.Observability.html) directive
 which configure metrics, traces and logs export.
+Refer to the [ProSA book](https://worldline.github.io/ProSA/ch01-02-01-observability.html) for more details on how to configure this directive.
 
 Default value: `$prosa::params::observability`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,9 +63,44 @@
 #   Configures the ProSA [TelemetryLevel](https://docs.rs/prosa-utils/latest/prosa_utils/config/tracing/enum.TelemetryLevel.html) directive
 #   which adjusts the verbosity of telemetry messages recorded.
 #
+# @param telemetry_attributes
+#   Configures the ProSA [Telemetry Attributes](https://docs.rs/prosa-utils/latest/prosa_utils/config/observability/struct.Observability.html) directive
+#   which allows to add custom attributes to telemetry messages.
+#   Refer to the [ProSA book](https://worldline.github.io/ProSA/ch01-02-01-observability.html) for more details on how to configure this directive.
+#
+# @example Setting custom telemetry attributes
+#   class { 'prosa':
+#     telemetry_attributes => {
+#       'service.name' => 'prosa-service',
+#       'host.id'      => 'fdbf79e8af94cb7f9e8df36789187052',
+#     }
+#   }
+#
 # @param observability
 #   Configures the ProSA [Observability](https://docs.rs/prosa-utils/latest/prosa_utils/config/observability/struct.Observability.html) directive
 #   which configure metrics, traces and logs export.
+#   Refer to the [ProSA book](https://worldline.github.io/ProSA/ch01-02-01-observability.html) for more details on how to configure this directive.
+#
+# @example Setting custom observability configuration
+#   class { 'prosa':
+#     observability => {
+#       'metrics' => {
+#         'stdout' => {
+#           'level' => 'info',
+#         },
+#       },
+#       'traces'  => {
+#         'stdout' => {
+#           'level' => 'info',
+#         },
+#       },
+#       'logs'    => {
+#         'stdout' => {
+#           'level' => 'info',
+#         },
+#       },
+#     }
+#   }
 #
 class prosa (
   String $prosa_name                                              = $prosa::params::prosa_name,
@@ -82,6 +117,7 @@ class prosa (
   String $user                                                    = $prosa::params::user,
   String $group                                                   = $prosa::params::group,
   ProSA::TelemetryLevel $telemetry_level                          = $prosa::params::telemetry_level,
+  Optional[Hash[String, String]] $telemetry_attributes            = undef,
   Hash[String, Hash[String, Hash[String, String]]] $observability = $prosa::params::observability,
 ) inherits prosa::params {
   # declare ProSA user and group
@@ -113,9 +149,10 @@ class prosa (
     group   => $group,
     mode    => '0644',
     content => epp('prosa/prosa.yml.epp', {
-        'prosa_name'      => $prosa_name,
-        'telemetry_level' => $telemetry_level,
-        'observability'   => $observability,
+        'prosa_name'           => $prosa_name,
+        'telemetry_level'      => $telemetry_level,
+        'telemetry_attributes' => $telemetry_attributes,
+        'observability'        => $observability,
     }),
     require => File[$conf_dir],
     notify  => Class['prosa::service'],

--- a/spec/acceptance/processors_spec.rb
+++ b/spec/acceptance/processors_spec.rb
@@ -19,6 +19,10 @@ describe 'prosa::processors class' do
           prosa_name      => #{prosa_hash['prosa_name']},
           service_manage  => false,
           telemetry_level => 'warn',
+          telemetry_attributes => {
+            'service.name' => 'prosa-service',
+            'host.id'      => 'fdbf79e8af94cb7f9e8df36789187052',
+          },
           observability   => {
             'metrics' => {
               'prometheus' => {
@@ -70,6 +74,8 @@ describe 'prosa::processors class' do
 
     describe file("#{prosa_hash['conf_dir']}/prosa.yml") do
       it { is_expected.to contain 'name: prosa-acceptance' }
+      it { is_expected.to contain '    service.name: prosa-service' }
+      it { is_expected.to contain '    host.id: fdbf79e8af94cb7f9e8df36789187052' }
       it { is_expected.to contain '    prometheus:' }
     end
 

--- a/templates/prosa.yml.epp
+++ b/templates/prosa.yml.epp
@@ -1,5 +1,6 @@
 <%- | String                                           $prosa_name,
       ProSA::TelemetryLevel                            $telemetry_level = 'warn',
+      Optional[Hash[String, String]]                   $telemetry_attributes = undef,
       Hash[String, Hash[String, Hash[String, String]]] $observability
 | -%>
 # Main configuration file for ProSA: Managed by Puppet.
@@ -7,6 +8,12 @@
 name: <%= $prosa_name %>
 observability:
   level: <%= $telemetry_level %>
+<%- if $telemetry_attributes { -%>
+  attributes:
+  <%- $telemetry_attributes.each |$key, $value| { -%>
+    <%= $key %>: <%= $value %>
+  <%- } -%>
+<%- } -%>
 <%- if $observability { -%>
 <%- $observability.keys.each |$telemetry_type| { -%>
   <%= $telemetry_type %>:


### PR DESCRIPTION
ProSA can add attributes for observability to provide more information about the system it runs on.
This change allows configuring these attributes with the `telemetry_attributes` parameter.